### PR TITLE
Add setting for toggling WebGL support on/off.

### DIFF
--- a/content/browserOverlay.js
+++ b/content/browserOverlay.js
@@ -42,6 +42,7 @@ onLoad: function(evt)
       this.qj_Prefix_Tb_FM_Container = this.qj_Prefix_Tb_Container + 'Favorites_Menu_';
 
       this.qj_JS                  = 'JavaScript';
+      this.qj_WebGL               = 'WebGL';
       this.qj_J                   = 'Java';
       this.qj_F                   = 'Flash';
       this.qj_SL                  = 'Silverlight';
@@ -156,6 +157,7 @@ setStartupValues: function(startupType)
     this.setStartupValue(this.qj_I);
     this.setStartupValue(this.qj_J);
     this.setStartupValue(this.qj_JS);
+    this.setStartupValue(this.qj_WebGL);
     this.setStartupValue(this.qj_F);
     this.setStartupValue(this.qj_SL);
     this.setStartupValue(this.qj_AI);
@@ -249,6 +251,7 @@ onClick: function(event)
         this.toggleEnabledIfStatusbarVisible(this.qj_I);
         this.toggleEnabledIfStatusbarVisible(this.qj_J);
         this.toggleEnabledIfStatusbarVisible(this.qj_JS);
+        this.toggleEnabledIfStatusbarVisible(this.qj_WebGL);
         this.toggleEnabledIfStatusbarVisible(this.qj_F);
         this.toggleEnabledIfStatusbarVisible(this.qj_SL);
         this.toggleEnabledIfStatusbarVisible(this.qj_AI);
@@ -294,6 +297,7 @@ onCommandFavorites: function(event)
         doReload = (this.toggleEnabledIfFavorite(this.qj_I, turnOn) && this.checkForReload(this.qj_I)) || doReload;
         doReload = (this.toggleEnabledIfFavorite(this.qj_J, turnOn) && this.checkForReload(this.qj_J)) || doReload;
         doReload = (this.toggleEnabledIfFavorite(this.qj_JS, turnOn) && this.checkForReload(this.qj_JS)) || doReload;
+        doReload = (this.toggleEnabledIfFavorite(this.qj_WebGL, turnOn) && this.checkForReload(this.qj_WebGL)) || doReload;
         doReload = (this.toggleEnabledIfFavorite(this.qj_F, turnOn) && this.checkForReload(this.qj_F)) || doReload;
         doReload = (this.toggleEnabledIfFavorite(this.qj_SL, turnOn) && this.checkForReload(this.qj_SL)) || doReload;
         doReload = (this.toggleEnabledIfFavorite(this.qj_AI, turnOn) && this.checkForReload(this.qj_AI)) || doReload;
@@ -327,6 +331,7 @@ reset_pref_click: function(event, whichReset)
 GetTypeFromId: function(id)
   {
     if (id == this.qj_Prefix_Sb_Container + this.qj_JS || id == this.qj_Prefix_Tb_Container + this.qj_JS || id == this.qj_Prefix_Tb_FM_Container + this.qj_JS) { return this.qj_JS; }
+    if (id == this.qj_Prefix_Sb_Container + this.qj_WebGL || id == this.qj_Prefix_Tb_Container + this.qj_WebGL || id == this.qj_Prefix_Tb_FM_Container + this.qj_WebGL) { return this.qj_WebGL; }
     if (id == this.qj_Prefix_Sb_Container + this.qj_J  || id == this.qj_Prefix_Tb_Container + this.qj_J || id == this.qj_Prefix_Tb_FM_Container + this.qj_J)  { return this.qj_J; }
     if (id == this.qj_Prefix_Sb_Container + this.qj_F  || id == this.qj_Prefix_Tb_Container + this.qj_F || id == this.qj_Prefix_Tb_FM_Container + this.qj_F)  { return this.qj_F; }
     if (id == this.qj_Prefix_Sb_Container + this.qj_SL || id == this.qj_Prefix_Tb_Container + this.qj_SL || id == this.qj_Prefix_Tb_FM_Container + this.qj_SL) { return this.qj_SL; }
@@ -352,6 +357,7 @@ updateIconsNow: function()
     {
       //Set the icons
       this.setIcon(this.qj_JS, this.isEnabled(this.qj_JS));
+      this.setIcon(this.qj_WebGL, this.isEnabled(this.qj_WebGL));
       this.setIcon(this.qj_J,  this.isEnabled(this.qj_J));
       this.setIcon(this.qj_F,  this.isEnabled(this.qj_F));
       this.setIcon(this.qj_SL, this.isEnabled(this.qj_SL));
@@ -454,6 +460,10 @@ toggleEnabled: function(whichIcon) {
   if (whichIcon == this.qj_JS)
   {
     this.prefs.setBoolPref("javascript.enabled", setEnabled);
+  }
+  else if (whichIcon == this.qj_WebGL)
+  {
+    this.prefs.setBoolPref("webgl.disabled", !setEnabled);
   }
   else if (whichIcon == this.qj_AI)
   {
@@ -606,6 +616,7 @@ showOptions: function() {
 isEnabled: function(whichIcon) {
   if (typeof(Ci) == 'undefined') { return false; } //This is not a normal window (example: options dialog)
   if (whichIcon == this.qj_JS) { return this.prefs.getBoolPref("javascript.enabled"); }
+  if (whichIcon == this.qj_WebGL) { return this.prefs.getBoolPref("webgl.disabled") == false; }
   if (whichIcon == this.qj_AI) { return (this.prefs.getCharPref("image.animation_mode") == "normal"); }
 
   if (whichIcon == this.qj_C)  { return (this.prefs.getIntPref("network.cookie.cookieBehavior") != 2); }
@@ -641,6 +652,7 @@ isEnabledAllFavorites: function()
   return (!this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_I) || this.isEnabled(this.qj_I))
       && (!this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_J) || this.isEnabled(this.qj_J))
       && (!this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_JS) || this.isEnabled(this.qj_JS))
+      && (!this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_WebGL) || this.isEnabled(this.qj_WebGL))
       && (!this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_F) || this.isEnabled(this.qj_F))
       && (!this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_SL) || this.isEnabled(this.qj_SL))
       && (!this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_AI) || this.isEnabled(this.qj_AI))
@@ -654,6 +666,7 @@ isEnabledAnyFavorites: function()
   return (this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_I) && this.isEnabled(this.qj_I))
       || (this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_J) && this.isEnabled(this.qj_J))
       || (this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_JS) && this.isEnabled(this.qj_JS))
+      || (this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_WebGL) && this.isEnabled(this.qj_WebGL))
       || (this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_F) && this.isEnabled(this.qj_F))
       || (this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_SL) && this.isEnabled(this.qj_SL))
       || (this.prefs.getBoolPref(this.qj_Prefix_Pref_Fav + this.qj_AI) && this.isEnabled(this.qj_AI))

--- a/content/browserOverlay.xul
+++ b/content/browserOverlay.xul
@@ -43,6 +43,16 @@
       </hbox>
     </statusbarpanel>
 
+    <statusbarpanel context="quickjava_contextmenu" class="statusbarpanel-iconic-text QuickJava_StatusIcon_Container" id="QuickJava_StatusIcon_Container_WebGL" tooltip="QuickJava_status_tip_WebGL" onclick="thatoneguydotnet.QuickJava.onClick(event);">
+      <hbox>
+        <vbox>
+          <spacer flex="1" />
+          <label id="QuickJava_StatusIcon_WebGL" class="quickjava-button" value="GL"/>
+          <spacer flex="1" />
+        </vbox>
+      </hbox>
+    </statusbarpanel>
+
     <statusbarpanel context="quickjava_contextmenu" class="statusbarpanel-iconic-text QuickJava_StatusIcon_Container" id="QuickJava_StatusIcon_Container_Silverlight" tooltip="QuickJava_status_tip_Silverlight" onclick="thatoneguydotnet.QuickJava.onClick(event);">
       <hbox>
         <vbox>
@@ -127,6 +137,11 @@
       <label id="QuickJava_ToolbarIcon_Silverlight" class="quickjava-button" value="SL" />
     </toolbarbutton>
 
+    <toolbarbutton id="QuickJava_ToolbarIcon_Container_Silverlight" label="&quickjava.webgl;"
+      oncommand="thatoneguydotnet.QuickJava.onCommand(event);" tooltiptext="&quickjava.tooltip.webgl;" context="quickjava_contextmenu" >
+      <label id="QuickJava_ToolbarIcon_Silverlight" class="quickjava-button" value="SL" />
+    </toolbarbutton>
+
     <toolbarbutton id="QuickJava_ToolbarIcon_Container_AnimatedImage" label="&quickjava.animage;"
       oncommand="thatoneguydotnet.QuickJava.onCommand(event);" tooltiptext="&quickjava.tooltip.animage;" context="quickjava_contextmenu" >
       <label id="QuickJava_ToolbarIcon_AnimatedImage" class="quickjava-button" value="A" />
@@ -166,6 +181,7 @@
            <menuitem label="J" value="J" id="QuickJava_ToolbarIcon_Container_Favorites_Menu_Java" type="checkbox" oncommand="thatoneguydotnet.QuickJava.onCommand(event);" />
            <menuitem label="F" value="F" id="QuickJava_ToolbarIcon_Container_Favorites_Menu_Flash" type="checkbox" oncommand="thatoneguydotnet.QuickJava.onCommand(event);" />
            <menuitem label="SL" value="SL" id="QuickJava_ToolbarIcon_Container_Favorites_Menu_Silverlight" type="checkbox" oncommand="thatoneguydotnet.QuickJava.onCommand(event);" />
+           <menuitem label="GL" value="WebGL" id="QuickJava_ToolbarIcon_Container_Favorites_Menu_WebGL" type="checkbox" oncommand="thatoneguydotnet.QuickJava.onCommand(event);" />
            <menuitem label="A" value="A" id="QuickJava_ToolbarIcon_Container_Favorites_Menu_AnimatedImage" type="checkbox" oncommand="thatoneguydotnet.QuickJava.onCommand(event);" />
            <menuitem label="C" value="C" id="QuickJava_ToolbarIcon_Container_Favorites_Menu_Cookies" type="checkbox" oncommand="thatoneguydotnet.QuickJava.onCommand(event);" />
            <menuitem label="I" value="I" id="QuickJava_ToolbarIcon_Container_Favorites_Menu_Images" type="checkbox" oncommand="thatoneguydotnet.QuickJava.onCommand(event);" />
@@ -199,6 +215,12 @@
     <tooltip id="QuickJava_status_tip_Silverlight" noautohide="true" orient="horizontal">
       <hbox>
         <description value="&quickjava.tooltip.silverlight;" id="QuickJava_status_tip_desc_Silverlight"/>
+      </hbox>
+    </tooltip>
+
+    <tooltip id="QuickJava_status_tip_WebGL" noautohide="true" orient="horizontal">
+      <hbox>
+        <description value="&quickjava.tooltip.webgl;" id="QuickJava_status_tip_desc_WebGL"/>
       </hbox>
     </tooltip>
     

--- a/content/options.xul
+++ b/content/options.xul
@@ -11,6 +11,7 @@
     <script type="application/x-javascript" src="chrome://quickjava/content/browserOverlay.js" />
     <preferences>
       <preference id="thatoneguydotnet_quickjava_pref_hidestatus_javascript"          name="thatoneguydotnet.QuickJava.hidestatus.JavaScript"     type="bool"/>
+      <preference id="thatoneguydotnet_quickjava_pref_hidestatus_webgl"               name="thatoneguydotnet.QuickJava.hidestatus.WebGL"          type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_hidestatus_java"                name="thatoneguydotnet.QuickJava.hidestatus.Java"           type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_hidestatus_flash"               name="thatoneguydotnet.QuickJava.hidestatus.Flash"          type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_hidestatus_silverlight"         name="thatoneguydotnet.QuickJava.hidestatus.Silverlight"    type="bool"/>
@@ -29,6 +30,7 @@
 
       <preference id="thatoneguydotnet_quickjava_pref_startupStatus_type"             name="thatoneguydotnet.QuickJava.startupStatus.type"           type="int"/>
       <preference id="thatoneguydotnet_quickjava_pref_startupStatus_javascript"       name="thatoneguydotnet.QuickJava.startupStatus.JavaScript"     type="int"/>
+      <preference id="thatoneguydotnet_quickjava_pref_startupStatus_webgl"            name="thatoneguydotnet.QuickJava.startupStatus.WebGL"          type="int"/>
       <preference id="thatoneguydotnet_quickjava_pref_startupStatus_java"             name="thatoneguydotnet.QuickJava.startupStatus.Java"           type="int"/>
       <preference id="thatoneguydotnet_quickjava_pref_startupStatus_flash"            name="thatoneguydotnet.QuickJava.startupStatus.Flash"          type="int"/>
       <preference id="thatoneguydotnet_quickjava_pref_startupStatus_silverlight"      name="thatoneguydotnet.QuickJava.startupStatus.Silverlight"    type="int"/>
@@ -41,6 +43,7 @@
       <preference id="thatoneguydotnet_quickjava_pref_favorites_differentDisplay"     name="thatoneguydotnet.QuickJava.favorites.differentDisplay"  type="int"/>
       <preference id="thatoneguydotnet_quickjava_pref_favorites_differentToggle"      name="thatoneguydotnet.QuickJava.favorites.differentToggle"   type="int"/>
       <preference id="thatoneguydotnet_quickjava_pref_favorites_javascript"           name="thatoneguydotnet.QuickJava.favorites.JavaScript"     type="bool"/>
+      <preference id="thatoneguydotnet_quickjava_pref_favorites_webgl"                name="thatoneguydotnet.QuickJava.favorites.WebGL"          type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_favorites_java"                 name="thatoneguydotnet.QuickJava.favorites.Java"           type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_favorites_flash"                name="thatoneguydotnet.QuickJava.favorites.Flash"          type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_favorites_silverlight"          name="thatoneguydotnet.QuickJava.favorites.Silverlight"    type="bool"/>
@@ -51,6 +54,7 @@
       <preference id="thatoneguydotnet_quickjava_pref_favorites_proxy"                name="thatoneguydotnet.QuickJava.favorites.Proxy"          type="bool"/>
 
       <preference id="thatoneguydotnet_quickjava_pref_reload_javascript"              name="thatoneguydotnet.QuickJava.reload.JavaScript"        type="bool"/>
+      <preference id="thatoneguydotnet_quickjava_pref_reload_webgl"                   name="thatoneguydotnet.QuickJava.reload.WebGL"             type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_reload_java"                    name="thatoneguydotnet.QuickJava.reload.Java"              type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_reload_flash"                   name="thatoneguydotnet.QuickJava.reload.Flash"             type="bool"/>
       <preference id="thatoneguydotnet_quickjava_pref_reload_silverlight"             name="thatoneguydotnet.QuickJava.reload.Silverlight"       type="bool"/>
@@ -81,6 +85,7 @@
               <row>
                 <label    value=""                                                            id="prompt_lbl" />
                 <label    value="&quickjava.javascript;"                                      id="prompt_javascript_lbl" />
+                <label    value="&quickjava.webgl;"                                           id="prompt_webgl_lbl" />
                 <label    value="&quickjava.cookies;"                                         id="prompt_cookies_lbl" />
                 <label    value="&quickjava.java;"                                            id="prompt_java_lbl" />
                 <label    value="&quickjava.flash;"                                           id="prompt_flash_lbl" />
@@ -93,6 +98,7 @@
               <row>
                 <label    value="&quickjava.options.hidestatusprompt;"                        id="hidestatus_prompt_lbl" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_hidestatus_javascript"  id="hidestatus_javascript_cb" />
+                <checkbox preference="thatoneguydotnet_quickjava_pref_hidestatus_webgl"       id="hidestatus_webgl_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_hidestatus_cookies"     id="hidestatus_cookies_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_hidestatus_java"        id="hidestatus_java_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_hidestatus_flash"       id="hidestatus_flash_cb" />
@@ -105,6 +111,7 @@
               <row>
                 <label    value="&quickjava.options.favoritesprompt;"                        id="favorites_prompt_lbl" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_favorites_javascript"  id="favorites_javascript_cb" />
+                <checkbox preference="thatoneguydotnet_quickjava_pref_favorites_webgl"       id="favorites_webgl_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_favorites_cookies"     id="favorites_cookies_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_favorites_java"        id="favorites_java_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_favorites_flash"       id="favorites_flash_cb" />
@@ -117,6 +124,7 @@
               <row>
                 <label    value="&quickjava.options.reloadprompt;"                        id="reload_prompt_lbl" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_reload_javascript"  id="reload_javascript_cb" />
+                <checkbox preference="thatoneguydotnet_quickjava_pref_reload_webgl"       id="reload_webgl_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_reload_cookies"     id="reload_cookies_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_reload_java"        id="reload_java_cb" />
                 <checkbox preference="thatoneguydotnet_quickjava_pref_reload_flash"       id="reload_flash_cb" />
@@ -138,6 +146,13 @@
                   </menulist>
                 </hbox>
                 <menulist preference="thatoneguydotnet_quickjava_pref_startupStatus_javascript"     id="startupStatus_javascript_cb">
+                  <menupopup>
+                    <menuitem label="&quickjava.options.nochange;" value="0" />
+                    <menuitem label="&quickjava.options.on;" value="1" />
+                    <menuitem label="&quickjava.options.off;" value="2" />
+                  </menupopup>
+                </menulist>
+                <menulist preference="thatoneguydotnet_quickjava_pref_startupStatus_webgl"       id="startupStatus_webgl_cb">
                   <menupopup>
                     <menuitem label="&quickjava.options.nochange;" value="0" />
                     <menuitem label="&quickjava.options.on;" value="1" />

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -2,6 +2,7 @@ pref("thatoneguydotnet.QuickJava.curVersion",               '');
 
 /* which icons are hidden in status/addon bar */
 pref("thatoneguydotnet.QuickJava.hidestatus.JavaScript",    false);
+pref("thatoneguydotnet.QuickJava.hidestatus.WebGL",         false);
 pref("thatoneguydotnet.QuickJava.hidestatus.Java",          false);
 pref("thatoneguydotnet.QuickJava.hidestatus.Flash",         false);
 pref("thatoneguydotnet.QuickJava.hidestatus.Silverlight",   false);
@@ -16,6 +17,7 @@ pref("thatoneguydotnet.QuickJava.startupStatus.type",          0);
 
 /* 0 = no change, 1 = enabled, 2 = disabled */
 pref("thatoneguydotnet.QuickJava.startupStatus.JavaScript",    0);
+pref("thatoneguydotnet.QuickJava.startupStatus.WebGL",         0);
 pref("thatoneguydotnet.QuickJava.startupStatus.Java",          0);
 pref("thatoneguydotnet.QuickJava.startupStatus.Flash",         0);
 pref("thatoneguydotnet.QuickJava.startupStatus.Silverlight",   0);
@@ -27,6 +29,7 @@ pref("thatoneguydotnet.QuickJava.startupStatus.Proxy",         0);
 
 /* which icons are visible in the favorites menu button */
 pref("thatoneguydotnet.QuickJava.favorites.JavaScript",     true);
+pref("thatoneguydotnet.QuickJava.favorites.WebGL",          true);
 pref("thatoneguydotnet.QuickJava.favorites.Java",           true);
 pref("thatoneguydotnet.QuickJava.favorites.Flash",          true);
 pref("thatoneguydotnet.QuickJava.favorites.Silverlight",    false);
@@ -42,6 +45,7 @@ pref("thatoneguydotnet.QuickJava.favorites.differentToggle",          0);
 
 /* which icons cause a reload of the page when they are changed */
 pref("thatoneguydotnet.QuickJava.reload.JavaScript",        false);
+pref("thatoneguydotnet.QuickJava.reload.WebGL",             false);
 pref("thatoneguydotnet.QuickJava.reload.Java",              false);
 pref("thatoneguydotnet.QuickJava.reload.Flash",             false);
 pref("thatoneguydotnet.QuickJava.reload.Silverlight",       false);

--- a/locale/en-US/quickjava.dtd
+++ b/locale/en-US/quickjava.dtd
@@ -1,6 +1,7 @@
 <!ENTITY quickjava.javascript               "Javascript">
 <!ENTITY quickjava.java                     "Java">
 <!ENTITY quickjava.flash                    "Flash">
+<!ENTITY quickjava.webgl                    "WebGL">
 <!ENTITY quickjava.silverlight              "SilverLight">
 <!ENTITY quickjava.animage                  "Animated Images">
 <!ENTITY quickjava.cookies                  "Cookies">
@@ -13,6 +14,7 @@
 <!ENTITY quickjava.tooltip.javascript     "Enable/Disable Javascript">
 <!ENTITY quickjava.tooltip.java           "Enable/Disable Java">
 <!ENTITY quickjava.tooltip.flash          "Enable/Disable Flash">
+<!ENTITY quickjava.tooltip.webgl          "Enable/Disable WebGL">
 <!ENTITY quickjava.tooltip.silverlight    "Enable/Disable SilverLight">
 <!ENTITY quickjava.tooltip.animage        "Enable/Disable Animated Images">
 <!ENTITY quickjava.tooltip.cookies        "Enable/Disable Cookies">

--- a/locale/es/quickjava.dtd
+++ b/locale/es/quickjava.dtd
@@ -1,6 +1,7 @@
 ﻿<!ENTITY quickjava.javascript               "Javascript">
 <!ENTITY quickjava.java                     "Java">
 <!ENTITY quickjava.flash                    "Flash">
+<!ENTITY quickjava.webgl                    "WebGL">
 <!ENTITY quickjava.silverlight              "SilverLight">
 <!ENTITY quickjava.animage                  "Imágenes animadas">
 <!ENTITY quickjava.cookies                  "Cookies">
@@ -13,6 +14,7 @@
 <!ENTITY quickjava.tooltip.javascript     "Habilita/Deshabilita Javascript">
 <!ENTITY quickjava.tooltip.java           "Habilita/Deshabilita Java">
 <!ENTITY quickjava.tooltip.flash          "Habilita/Deshabilita Flash">
+<!ENTITY quickjava.tooltip.webgl          "Habilita/Deshabilita WebGL">
 <!ENTITY quickjava.tooltip.silverlight    "Habilita/Deshabilita SilverLight">
 <!ENTITY quickjava.tooltip.animage        "Habilita/Deshabilita imágenes animadas">
 <!ENTITY quickjava.tooltip.cookies        "Habilita/Deshabilita cookies">


### PR DESCRIPTION
Hi. I've added the feature of being able to toggle WebGL support on and off, as it's something I've wanted myself. The reason is that enabled WebGL is generally a nice remote attack vector, similarly to Flash etc. and thus enabling it only when needed is rather useful.